### PR TITLE
Using a range for the django-bakery requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ docs_require = [
 ]
 
 test_require = [
-    'factory-boy==2.7.0',
-    'flake8==3.2.0',
+    'factory-boy==2.8.1',
+    'flake8==3.2.1',
     'isort==4.2.5',
-    'pytest==3.0.4',
+    'pytest==3.0.5',
     'pytest-cov==2.4.0',
-    'pytest-django==3.1.1',
+    'pytest-django==3.1.2',
     'wagtail>=1.7,<1.8',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'django-bakery==0.8.11',
+    'django-bakery>=0.8.12,<1.0.0',
 ]
 
 docs_require = [
@@ -21,7 +21,7 @@ test_require = [
 
 setup(
     name='wagtail-bakery',
-    version='0.1.0',
+    version='0.1.1',
     description='A set of helpers for baking your Django Wagtail site out as flat files.',
     author='Rob Moorman',
     author_email='rob@moori.nl',


### PR DESCRIPTION
This prevents the dependency from becoming stale when new updates are released; but avoids errors from a major version bump.