### PR TITLE
 Add views for rendering a static API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Wagtail-bakery is built on top of [Django bakery](https://github.com/datadesk/dj
 * Single management command that will build your Wagtail site out as flat files
 * Support for multisite, [theming](https://github.com/moorinteractive/wagtail-themes) and [multilingual](http://docs.wagtail.io/en/latest/advanced_topics/i18n/index.html) setup
 * Support for `i18n_patterns`
+* Support for generating a static API
 * Ready to use Wagtail Buildable views to build all your (un)published pages at once (no extra code required!)
 
 ## Installation
@@ -66,6 +67,17 @@ BAKERY_VIEWS = (
 	'wagtailbakery.views.AllPagesView',
 )
 ```
+
+To build a static pages API, use the following views:
+
+```python
+BAKERY_VIEWS = (
+	'wagtailbakery.api_views.PagesAPIDetailView',
+	'wagtailbakery.api_views.PagesAPIListingView',
+	'wagtailbakery.api_views.TypedPagesAPIListingView',
+)
+
+The API views use Wagtail's V2 API module. To configure the data that is rendered by these views, please refer to Wagtail's [V2 API configuration guide](http://docs.wagtail.io/en/stable/advanced_topics/api/v2/configuration.html).
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'django-bakery==0.9.2',
+    'django-bakery==0.12.3',
     'six>=1.10.0',
     'wagtail>=1.6',
 ]

--- a/src/wagtailbakery/api_views.py
+++ b/src/wagtailbakery/api_views.py
@@ -1,0 +1,198 @@
+import logging
+import os
+import json
+
+from bakery.views import BuildableMixin
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from wagtail.wagtailcore.models import Page, Site
+from wagtail.api.v2.endpoints import PagesAPIEndpoint
+from wagtail.api.v2.router import WagtailAPIRouter
+from wagtail.api.v2.pagination import WagtailPagination
+
+
+logger = logging.getLogger(__name__)
+
+
+class APIResponseError(Exception):
+    pass
+
+
+def handle_api_error(response):
+    if response.status_code == 400:
+        raise APIResponseError("API error: " + json.loads(response.render().content.decode('UTF-8'))['message'])
+
+    raise APIResponseError("Unexpected status code returned from API: %d" % response.status_code)
+
+
+def ensure_dir_exists(fs, filename):
+    dirname = os.path.dirname(filename)
+    if not fs.exists(dirname):
+        fs.makedirs(dirname)
+
+
+class APIListingView(BuildableMixin):
+    results_per_page = 20
+
+    @property
+    def build_method(self):
+        return self.build
+
+    def get_build_path(self, page_num):
+        """
+        Override this to return the path of the file to be built
+        """
+        raise NotImplementedError
+
+    def build(self):
+        page_num = 0
+        has_next_page = True
+
+        while has_next_page:
+            target_path = os.path.join(settings.BUILD_DIR, self.get_build_path(page_num + 1))
+            ensure_dir_exists(self.fs, target_path)
+            page_content, has_next_page = self.get_content(page_num)
+            self.build_file(target_path, page_content)
+
+            page_num += 1
+
+
+class APIDetailView(BuildableMixin):
+    """
+    Render and build a "detail" view of an object.
+
+    Required attributes:
+
+        endpoint_class:
+            The Wagtail API endpoint class to use for generating the
+            JSON documents
+
+        get_queryset:
+            A method that returns a queryset of objects to include
+    """
+    @property
+    def build_method(self):
+        return self.build_queryset
+
+    def get_build_path(self, obj):
+        """
+        Override this to return the path of the file to be built
+        """
+        raise NotImplementedError
+
+    def build_object(self, obj):
+        target_path = os.path.join(settings.BUILD_DIR, self.get_build_path(obj))
+        ensure_dir_exists(self.fs, target_path)
+        self.build_file(target_path, self.get_content(obj))
+
+    def build_queryset(self):
+        [self.build_object(o) for o in self.get_queryset().all()]
+
+    def unbuild_object(self, obj):
+        """
+        Deletes the file at self.get_build_path()
+        """
+        logger.debug("Unbuilding %s" % obj)
+        target_path = os.path.join(settings.BUILD_DIR, self.get_build_path(obj))
+        if self.fs.exists(target_path):
+            logger.debug("Removing {}".format(target_path))
+            self.fs.remove(target_path)
+
+    def get_content(self, obj):
+        # Create a dummy request
+        request = self.create_request('/?format=json&fields=*')
+        request.site = Site.objects.get(is_default_site=True)
+        request.wagtailapi_router = WagtailAPIRouter('')
+
+        response = self.endpoint_class.as_view({'get': 'detail_view'})(request, pk=obj.pk)
+
+        if response.status_code == 200:
+            return response.render().content
+
+        handle_api_error(response)
+
+class PagesAPIDetailView(APIDetailView):
+    """
+    Builds detail documents for every published page.
+
+    URL example: /api/pages/detail/1.json
+    """
+    endpoint_class = PagesAPIEndpoint
+
+    def get_build_path(self, page):
+        return 'api/pages/detail/{pk}.json'.format(pk=page.pk)
+
+    def get_queryset(self):
+        if getattr(settings, 'BAKERY_MULTISITE', False):
+            return Page.objects.all().public().live()
+        else:
+            site = Site.objects.get(is_default_site=True)
+            return site.root_page.get_descendants(inclusive=True).public().live()
+
+
+class PagesAPIListingView(APIListingView):
+    """
+    Builds a single listing that lists every published page.
+
+    URL example: /api/pages/1.json
+    """
+    def get_build_path(self, page_num):
+        return 'api/pages/{page_num}.json'.format(page_num=page_num)
+
+    def fetch_page_listing(self, page_num, model=None):
+        if model:
+            url = '/?format=json&fields=*&limit={}&offset={}&type={}.{}'.format(self.results_per_page, self.results_per_page * page_num, model._meta.app_label, model.__name__)
+        else:
+            url = '/?format=json&fields=*&limit={}&offset={}'.format(self.results_per_page, self.results_per_page * page_num)
+
+        request = self.create_request(url)
+        request.site = Site.objects.get(is_default_site=True)
+        request.wagtailapi_router = WagtailAPIRouter('')
+        response = PagesAPIEndpoint.as_view({'get': 'listing_view'})(request)
+
+        if response.status_code == 200:
+            content = response.render().content
+            has_next_page = json.loads(content.decode('UTF-8'))['meta']['total_count'] > self.results_per_page * (page_num + 1)
+            return content, has_next_page
+
+        handle_api_error(response)
+
+    def get_content(self, page_num):
+        return self.fetch_page_listing(page_num)
+
+
+class TypedPagesAPIListingView(PagesAPIListingView):
+    """
+    Builds a listing for each page type. Containing all published
+    pages of that type.
+
+    URL example: /api/pages/blog_BlogPage/1.json
+    """
+    def get_build_path(self, model, page_num):
+        return 'api/pages/{app_label}_{class_name}/{page_num}.json'.format(
+            app_label=model._meta.app_label,
+            class_name=model.__name__,
+            page_num=page_num,
+        )
+
+    def get_content(self, model, page_num):
+        return self.fetch_page_listing(page_num, model=model)
+
+    def get_page_models(self):
+        return [
+            content_type.model_class()
+            for content_type in ContentType.objects.filter(id__in=Page.objects.values_list('content_type_id', flat=True))
+        ]
+
+    def build(self):
+        for model in self.get_page_models():
+            page_num = 0
+            has_next_page = True
+
+            while has_next_page:
+                target_path = os.path.join(settings.BUILD_DIR, self.get_build_path(model, page_num + 1))
+                ensure_dir_exists(self.fs, target_path)
+                page_content, has_next_page = self.get_content(model, page_num)
+                self.build_file(target_path, page_content)
+
+                page_num += 1

--- a/src/wagtailbakery/models.py
+++ b/src/wagtailbakery/models.py
@@ -1,13 +1,11 @@
 from bakery.models import AutoPublishingBuildableModel, BuildableModel
 
-from wagtailbakery.views import WagtailBakeryView
-
 
 class BuildableWagtailBakeryModel(BuildableModel):
     """
     Buildable Wagtail bakery page model mixin class.
     """
-    detail_views = (WagtailBakeryView,)
+    detail_views = ['wagtailbakery.views.WagtailBakeryView']
 
     def _build_related(self):
         # TODO: Build related pages with get_static_site_paths
@@ -21,7 +19,7 @@ class AutoPublishingWagtailBakeryModel(AutoPublishingBuildableModel):
     """
     Auto publishing Wagtail bakery page model mixin class.
     """
-    detail_views = (WagtailBakeryView,)
+    detail_views = ['wagtailbakery.views.WagtailBakeryView']
     publication_status_field = 'live'
 
     def _build_related(self):

--- a/tests/integration/test_api_views.py
+++ b/tests/integration/test_api_views.py
@@ -1,0 +1,151 @@
+import json
+
+import pytest
+from django.conf import settings
+
+from wagtailbakery.api_views import PagesAPIDetailView, PagesAPIListingView, TypedPagesAPIListingView
+from ..models import EventPage
+
+
+DEFAULT_PAGE_FIELDS = {'id', 'meta', 'title'}
+DEFAULT_PAGE_META_FIELDS = {'type', 'show_in_menus', 'search_description', 'first_published_at', 'slug', 'html_url', 'seo_title'}
+
+
+@pytest.mark.django_db
+def test_wagtail_bakery_pages_api_detail_view(page_tree):
+    view = PagesAPIDetailView()
+
+    # Check build path
+    build_path = view.get_build_path(page_tree)
+    assert build_path == 'api/pages/detail/2.json'
+
+    # Check child build path for first child page
+    child_page = page_tree.get_descendants().first()
+    build_path = view.get_build_path(child_page)
+    assert build_path == 'api/pages/detail/3.json'
+
+    # Check child build path of the first child page
+    child_page = child_page.get_descendants().first()
+    build_path = view.get_build_path(child_page)
+    assert build_path == 'api/pages/detail/6.json'
+
+
+@pytest.mark.django_db
+def test_wagtail_bakery_pages_api_detail_view_build_path_for_multisite(multisite):
+    view = PagesAPIDetailView()
+    site = multisite[0]
+    page = site.root_page
+
+    # Check build path for homepage
+    build_path = view.get_build_path(page)
+    assert build_path == 'api/pages/detail/2.json'
+
+
+@pytest.mark.django_db
+def test_wagtail_bakery_pages_api_detail_view_content(page_tree):
+    view = PagesAPIDetailView()
+
+    # Check content for homepage
+    content = json.loads(view.get_content(page_tree))
+    assert set(content.keys()) == DEFAULT_PAGE_FIELDS
+    assert set(content['meta'].keys()) == DEFAULT_PAGE_META_FIELDS.union({'parent'})
+    assert content['id'] == 2
+    assert content['title'] == "Welcome to your new Wagtail site!"
+
+    # Check content for first child page
+    child_page = page_tree.get_descendants().first()
+    content = json.loads(view.get_content(child_page))
+    assert set(content.keys()) == DEFAULT_PAGE_FIELDS
+    assert set(content['meta'].keys()) == DEFAULT_PAGE_META_FIELDS.union({'parent'})
+    assert content['id'] == 3
+    assert content['title'] == "Page"
+
+    # Check content of the first grandchild page
+    grandchild_page = child_page.get_descendants().first()
+    content = json.loads(view.get_content(grandchild_page))
+    assert set(content.keys()) == DEFAULT_PAGE_FIELDS
+    assert set(content['meta'].keys()) == DEFAULT_PAGE_META_FIELDS.union({'parent'})
+    assert content['id'] == 6
+    assert content['title'] == "Page"
+
+
+@pytest.mark.django_db
+def test_wagtail_bakery_pages_api_listing_view():
+    view = PagesAPIListingView()
+
+    # Check build path
+    build_path = view.get_build_path(0)
+    assert build_path == 'api/pages/0.json'
+
+    # Check build path for second page
+    build_path = view.get_build_path(1)
+    assert build_path == 'api/pages/1.json'
+
+
+@pytest.mark.django_db
+def test_wagtail_bakery_pages_api_listing_view_build_path_for_multisite(multisite):
+    view = PagesAPIListingView()
+    site = multisite[0]
+    page = site.root_page
+
+    # Check build path for homepage
+    build_path = view.get_build_path(0)
+    assert build_path == 'api/pages/0.json'
+
+
+@pytest.mark.django_db
+def test_wagtail_bakery_pages_api_listing_view_content(page_tree):
+    view = PagesAPIListingView()
+
+    # Check content
+    content = json.loads(view.get_content(0)[0])
+    assert set(content.keys()) == {'meta', 'items'}
+    assert set(content['meta'].keys()) == {'total_count'}
+
+    page = content['items'][0]
+    assert set(page.keys()) == DEFAULT_PAGE_FIELDS
+    assert set(page['meta'].keys()) == DEFAULT_PAGE_META_FIELDS
+
+
+@pytest.mark.django_db
+def test_wagtail_bakery_typed_pages_api_listing_view():
+    view = TypedPagesAPIListingView()
+
+    # Check build path
+    build_path = view.get_build_path(EventPage, 0)
+    assert build_path == 'api/pages/tests_EventPage/0.json'
+
+    # Check build path for second page
+    build_path = view.get_build_path(EventPage, 1)
+    assert build_path == 'api/pages/tests_EventPage/1.json'
+
+
+@pytest.mark.django_db
+def test_wagtail_bakery_typed_pages_api_listing_view_build_path_for_multisite(multisite):
+    view = TypedPagesAPIListingView()
+    site = multisite[0]
+    page = site.root_page
+
+    # Check build path for homepage
+    build_path = view.get_build_path(EventPage, 0)
+    assert build_path == 'api/pages/tests_EventPage/0.json'
+
+
+@pytest.mark.django_db
+def test_wagtail_bakery_typed_pages_api_listing_view_content(page_tree):
+    view = TypedPagesAPIListingView()
+
+    page_tree.add_child(instance=EventPage(
+        title="Test event page",
+        slug="test-event-page",
+    ))
+
+    # Check content
+    content = json.loads(view.get_content(EventPage, 0)[0])
+    assert set(content.keys()) == {'meta', 'items'}
+    assert set(content['meta'].keys()) == {'total_count'}
+
+    page = content['items'][0]
+    assert set(page.keys()) == DEFAULT_PAGE_FIELDS
+    assert set(page['meta'].keys()) == DEFAULT_PAGE_META_FIELDS
+    assert page['title'] == "Test event page"


### PR DESCRIPTION
This implements three new views for rendering pages to static JSON files
using Wagtail's API module:

- ``PagesAPIDetailView`` renders detail pages at ``/api/pages/detail/{id}.json``
- ``PagesAPIListingView`` renders a full page listing at ``/api/pages/{page_num}.json``. Each page contains 20 results.
- ``TypedPagesAPIListingView`` renders a separate listing for each page type at ``/api/pages/{app_label}.{model_name}/{page_num}.json``. Unlike the standard listing view, this also includes all specific fields on that page type.

All rendering is done through Wagtail's v2 API module so any configuration the site has for that will be used by this static renderer.